### PR TITLE
Add 'Event' module

### DIFF
--- a/Source/Event/EventConnection.lua
+++ b/Source/Event/EventConnection.lua
@@ -1,0 +1,26 @@
+local Types = require(script.Parent.Types)
+
+export type EventConnection = Types.EventConnection
+
+local EventConnection = {}
+EventConnection.__index = EventConnection
+EventConnection.className = "EventConnection"
+
+function EventConnection.new(event: Types.Event): Types.EventConnection
+	local self = setmetatable({
+		_Event = event,
+	}, EventConnection)
+	return self :: Types.EventConnection
+end
+
+function EventConnection:Destroy()
+	self._Event = nil
+end
+
+function EventConnection:Disconnect()
+	if self._Event then
+		self._Event:Disconnect(self)
+	end
+end
+
+return EventConnection

--- a/Source/Event/Types.lua
+++ b/Source/Event/Types.lua
@@ -1,0 +1,16 @@
+export type EventConnection = {
+	className: string,
+	new: (event: Event) -> EventConnection,
+	Destroy: (self: EventConnection) -> (),
+	Disconnect: (self: EventConnection) -> ()
+}
+
+export type Event = {
+	className: string,
+	new: () -> Event,
+	Destroy: (self: Event) -> (),
+	Connect: (self: Event, callback: (...any) -> ()) -> EventConnection,
+	Fire: (self: Event, ...any) -> ()
+}
+
+return {}

--- a/Source/Event/init.lua
+++ b/Source/Event/init.lua
@@ -1,0 +1,68 @@
+local Types = require(script.Types)
+local EventConnection = require(script.EventConnection)
+
+export type Event = Types.Event
+export type EventConnection = Types.EventConnection
+
+local Event = {}
+Event.__index = Event
+Event.className = "Event"
+
+function Event.new(): Types.Event
+	local self = setmetatable({
+		_BindableEvent = Instance.new("BindableEvent"),
+		_BindableEventConnection = nil,
+		_Connections = {},
+		_Callbacks = {},
+		_Value = nil
+	}, Event)
+
+	self:_ConnectBindableEvent()
+
+	return self
+end
+
+function Event:Destroy()
+	for _, connection in pairs(self._Connections) do
+		connection:Destroy()
+	end
+	self._Connections = nil
+	self._Callbacks = nil
+	self._Value = nil
+	self._BindableEventConnection:Disconnect()
+	self._BindableEventConnection = nil
+	self._BindableEvent:Destroy()
+	self._BindableEvent = nil
+end
+
+function Event:_ConnectBindableEvent()
+	self._BindableEventConnection = self._BindableEvent.Event:Connect(function()
+		local value = table.unpack(self._Value)
+		for _, connection in pairs(self._Connections) do
+			local callback = self._Callbacks[connection]
+			callback(value)
+		end
+	end)
+end
+
+function Event:Connect(callback: (...any) -> ()): Types.EventConnection
+	local eventConnection = EventConnection.new(self)
+	self._Connections[eventConnection] = eventConnection
+	self._Callbacks[eventConnection] = callback
+	return eventConnection
+end
+
+function Event:Disconnect(eventConnection: Types.EventConnection)
+	if self._Connections[eventConnection] then
+		eventConnection:Destroy()
+		self._Connections[eventConnection] = nil
+		self._Callbacks[eventConnection] = nil
+	end
+end
+
+function Event:Fire(...: any)
+	self._Value = {...}
+	self._BindableEvent:Fire()
+end
+
+return Event

--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,27 @@
+{
+	"name": "roblox-utility",
+	"tree": {
+		"$className": "DataModel",
+		"ReplicatedStorage": {
+			"$className": "ReplicatedStorage",
+			"$path": "Tests/Shared",
+			"Packages": {
+				"$className": "Folder",
+				"Utility": {
+					"$path": "Source"
+				}
+			}
+		},
+		"ServerScriptService": {
+			"$className": "ServerScriptService",
+			"$path": "Tests/Server"
+		},
+		"StarterPlayer": {
+			"$className": "StarterPlayer",
+			"StarterPlayerScripts": {
+				"$className": "StarterPlayerScripts",
+				"$path": "Tests/Client"
+			}
+		}
+	}
+}

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,1 @@
+std = "roblox"


### PR DESCRIPTION
Add the Event module to roblox-utility. 

The Event module is a custom Signal implementation that wraps Roblox BinadableEvents and allows values to be passed through the `:Fire()` method without being copied.

> local event = Event.new()
> local connection = event:Connect(function(value)
> 	print("Event fired with value:", value)
> end)
> event:Fire("Hello, world!")
> connection:Disconnect()
> event:Destroy()